### PR TITLE
Akka streams 2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-target/*
-project/target/*
+/target/
+/project/target/
 
+# IntelliJ IDEA
+/.idea/

--- a/Example.scala
+++ b/Example.scala
@@ -4,12 +4,6 @@ import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 import akka.stream.Supervision.Decider
 import akka.stream.scaladsl._
-import akka.stream.OverflowStrategy
-import akka.stream.ActorAttributes
-import akka.actor.Cancellable
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import FlowGraph.Implicits._
 
 object Streams {
 
@@ -19,12 +13,12 @@ object Streams {
     ActorMaterializer(ActorMaterializerSettings(system)
                         .withSupervisionStrategy(decider))
 
-  val fast = Source(() => Iterator.fill(10)(()))
+  val fast = Source.fromIterator(() => Iterator.fill(10)(()))
                 .map(_ => println("with conflate"))
                 .conflate(List(_)){ (l, i) => i :: l }
                 .mapConcat(identity(_))
 
-  val slow = Source(() => Iterator.fill(10)(()))
+  val slow = Source.fromIterator(() => Iterator.fill(10)(()))
                 .map(_ => println("without conflate"))
 
   val via = Flow[Unit].map { _ =>

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ libraryDependencies ++= {
     // see https://github.com/etorreborre/specs2/issues/296#issuecomment-94796264
     "org.scalatest" %% "scalatest" % "latest.release" % "test",
     "org.scalacheck" %% "scalacheck" % "latest.release" % "test",
+
     "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.2",
     "org.scalaz" %% "scalaz-core" % scalazVer,
     "org.scalaz" %% "scalaz-effect" % scalazVer

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= {
     // see https://github.com/etorreborre/specs2/issues/296#issuecomment-94796264
     "org.scalatest" %% "scalatest" % "latest.release" % "test",
     "org.scalacheck" %% "scalacheck" % "latest.release" % "test",
-    "com.typesafe.akka" %% "akka-stream-experimental" % "1.0",
+    "com.typesafe.akka" %% "akka-stream-experimental" % "2.0.2",
     "org.scalaz" %% "scalaz-core" % scalazVer,
     "org.scalaz" %% "scalaz-effect" % scalazVer
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-name := """stream-example"""
+name := "stream-example"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -23,11 +23,14 @@ resolvers ++= Seq(
 
 resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
-libraryDependencies ++= Seq(
-  // see https://github.com/etorreborre/specs2/issues/296#issuecomment-94796264
-  "org.scalatest" %% "scalatest" % "latest.release" % "test",
-  "org.scalacheck" %% "scalacheck" % "latest.release" % "test",
-  "com.typesafe.akka" % "akka-stream-experimental_2.11" % "1.0",
-  "org.scalaz" %% "scalaz-core" % "7.1.0", //"latest.release",
-  "org.scalaz" %% "scalaz-effect" % "7.1.0" //"latest.release",
-)
+libraryDependencies ++= {
+  val scalazVer = "7.1.0"    // or "latest.release"
+  Seq(
+    // see https://github.com/etorreborre/specs2/issues/296#issuecomment-94796264
+    "org.scalatest" %% "scalatest" % "latest.release" % "test",
+    "org.scalacheck" %% "scalacheck" % "latest.release" % "test",
+    "com.typesafe.akka" %% "akka-stream-experimental" % "1.0",
+    "org.scalaz" %% "scalaz-core" % scalazVer,
+    "org.scalaz" %% "scalaz-effect" % scalazVer
+  )
+}


### PR DESCRIPTION
Modified the code so that it compiles with Akka Streams 2.0.2. Also tried running `StreamProgram.run` (but not the others).

There are some unconnected tips/suggestions here, too. And removals of unused imports. Please tell me if you wish things to change, I can then update the PR. :)

Reference: [Akka Streams 2.0.2 migration guide](http://doc.akka.io/docs/akka-stream-and-http-experimental/2.0.2/scala/migration-guide-1.0-2.x-scala.html)
